### PR TITLE
Add global seeding utility for reproducible training (P1 PR 6)

### DIFF
--- a/animal_id/common/__init__.py
+++ b/animal_id/common/__init__.py
@@ -7,3 +7,7 @@ Contains shared functionality used across all modules:
 - Inference pipeline utilities
 - Utility functions and helpers
 """
+
+from animal_id.common.seed import set_seed, worker_init_fn
+
+__all__ = ["set_seed", "worker_init_fn"]

--- a/animal_id/common/seed.py
+++ b/animal_id/common/seed.py
@@ -1,0 +1,27 @@
+import os
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int = 42, deterministic: bool = False) -> torch.Generator:
+    """Seed Python, NumPy, and PyTorch RNGs. Returns a Generator for DataLoader."""
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    if deterministic:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+    g = torch.Generator()
+    g.manual_seed(seed)
+    return g
+
+
+def worker_init_fn(worker_id: int) -> None:
+    """Per-worker seed derived from the main generator seed."""
+    seed = torch.initial_seed() % 2**32
+    np.random.seed(seed)
+    random.seed(seed)

--- a/animal_id/detection/trainer.py
+++ b/animal_id/detection/trainer.py
@@ -17,10 +17,14 @@ class DetectionTrainer:
     """Trainer for YOLO detection models."""
 
     def __init__(
-        self, model_name: str = "yolo11n.pt", config: Optional[Dict[str, Any]] = None
+        self,
+        model_name: str = "yolo11n.pt",
+        config: Optional[Dict[str, Any]] = None,
+        seed: int = 42,
     ):
         """Initialize trainer with model and configuration."""
         self.model_name = model_name
+        self.seed = seed
         self.config = config or self._get_default_config()
         self.model = None
 
@@ -38,6 +42,7 @@ class DetectionTrainer:
             "save_period": 5,
             "cache": False,
             "dropout": 0.1,
+            "seed": self.seed,
             # Augmentation settings
             "fliplr": 0.5,
             "degrees": 15.0,

--- a/animal_id/embedding/dataset_converter.py
+++ b/animal_id/embedding/dataset_converter.py
@@ -38,7 +38,7 @@ class EmbeddingDatasetConverter:
 
         # Scan DogFaceNet directory structure
         filtered_identities = {}
-        for identity_folder in os.listdir(self.source_path):
+        for identity_folder in sorted(os.listdir(self.source_path)):
             identity_path = os.path.join(self.source_path, identity_folder)
             if os.path.isdir(identity_path):
                 image_files = [

--- a/animal_id/keypoint/trainer.py
+++ b/animal_id/keypoint/trainer.py
@@ -20,9 +20,11 @@ class KeypointTrainer:
         self,
         model_name: str = "yolo11n-dog-pose.yaml",
         config: Optional[Dict[str, Any]] = None,
+        seed: int = 42,
     ):
         """Initialize trainer with model and configuration."""
         self.model_name = model_name
+        self.seed = seed
         self.config = config or self._get_default_config()
         self.model = None
 
@@ -39,6 +41,7 @@ class KeypointTrainer:
             "patience": 10,
             "save_period": 5,
             "cache": False,
+            "seed": self.seed,
             # Augmentation settings (more conservative for keypoints)
             "fliplr": 0.5,
             "degrees": 10,

--- a/scripts/train_master.py
+++ b/scripts/train_master.py
@@ -44,6 +44,7 @@ from animal_id.common.constants import (
 # --- Imports for Common/Utils ---
 from animal_id.common.datasets import IdentityDataset
 from animal_id.common.identity_loader import IdentityLoader
+from animal_id.common.seed import set_seed, worker_init_fn
 
 # --- Imports for Detection ---
 from animal_id.detection.dataset_converter import (
@@ -70,6 +71,8 @@ from animal_id.tracking.wandb_logger import WandBLogger
 
 # Define project root
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+SEED = 42
 
 
 # --- Logging Setup ---
@@ -343,6 +346,8 @@ def run_embedding_pipeline():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     logger.info(f"Using device: {device}")
 
+    g = set_seed(SEED)
+
     # Load Datasets
     train_dataset = IdentityDataset(
         json_path=PROJECT_ROOT / DATA_CONFIG["TRAIN_JSON_PATH"],
@@ -360,6 +365,8 @@ def run_embedding_pipeline():
         batch_size=DATA_CONFIG["BATCH_SIZE"],
         shuffle=True,
         num_workers=TRAINING_CONFIG["HARDWARE_WORKERS"],
+        generator=g,
+        worker_init_fn=worker_init_fn,
     )
     val_loader = DataLoader(
         val_dataset,

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -1,0 +1,55 @@
+import os
+import random
+
+import numpy as np
+import torch
+
+from animal_id.common.seed import set_seed, worker_init_fn
+
+
+def test_set_seed_returns_generator():
+    g = set_seed(42)
+    assert isinstance(g, torch.Generator)
+
+
+def test_set_seed_python_random():
+    set_seed(42)
+    a = random.random()
+    set_seed(42)
+    b = random.random()
+    assert a == b
+
+
+def test_set_seed_numpy():
+    set_seed(42)
+    a = np.random.rand()
+    set_seed(42)
+    b = np.random.rand()
+    assert a == b
+
+
+def test_set_seed_torch():
+    set_seed(42)
+    a = torch.rand(1).item()
+    set_seed(42)
+    b = torch.rand(1).item()
+    assert a == b
+
+
+def test_set_seed_env():
+    set_seed(7)
+    assert os.environ["PYTHONHASHSEED"] == "7"
+
+
+def test_different_seeds_differ():
+    set_seed(1)
+    a = torch.rand(1).item()
+    set_seed(2)
+    b = torch.rand(1).item()
+    assert a != b
+
+
+def test_worker_init_fn_runs():
+    # Should not raise; seeds derived from torch.initial_seed()
+    worker_init_fn(0)
+    worker_init_fn(3)


### PR DESCRIPTION
## Summary

- Adds `animal_id/common/seed.py` with `set_seed(seed, deterministic=False)` and `worker_init_fn` — seeds Python `random`, NumPy, PyTorch CPU+CUDA, and sets `PYTHONHASHSEED` from a single call; returns a `torch.Generator` for DataLoader
- Wires `SEED = 42` + `set_seed()` into `scripts/train_master.py`; passes `generator=` and `worker_init_fn=` to the training DataLoader
- Adds `seed=` param to `DetectionTrainer` and `KeypointTrainer`, forwarded into the Ultralytics config dict
- Fixes non-deterministic train/val splits in `EmbeddingDatasetConverter` by sorting `os.listdir()` before building the identity dict (the existing `random.seed(42)` shuffle was operating on a filesystem-ordered key list)
- 7 new unit tests in `tests/unit/test_seed.py`; 50/50 tests pass

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/unit/test_seed.py -v` — 7/7 pass
- [x] `pytest tests/` — 50/50 pass, no regressions