### PR TITLE
Add held-out test split for embedding eval (audit P1 #10)

### DIFF
--- a/animal_id/common/identity_loader.py
+++ b/animal_id/common/identity_loader.py
@@ -13,9 +13,17 @@ from .constants import DATA_DIR, PROJECT_ROOT
 class IdentityLoader:
     """Loads and manages identity validation data with optional augmentation."""
 
-    def __init__(self, seed: int = 42):
-        """Initialize with random seed for reproducible sampling."""
+    def __init__(self, seed: int = 42, json_filename: str = "identity_val.json"):
+        """Initialize with random seed for reproducible sampling.
+
+        Args:
+            seed: Random seed for reproducible sampling.
+            json_filename: Name of the base split JSON file (relative to DATA_DIR)
+                to load as the gallery/probe set. Defaults to the validation split;
+                pass ``identity_test.json`` to evaluate on the held-out test set.
+        """
         self.seed = seed
+        self.json_filename = json_filename
         random.seed(seed)
 
     def load_validation_data(
@@ -60,8 +68,8 @@ class IdentityLoader:
         )
 
     def _load_base_validation(self) -> List[Dict[str, str]]:
-        """Load base validation data from identity_val.json."""
-        val_json_path = DATA_DIR / "identity_val.json"
+        """Load base evaluation data from the configured split JSON file."""
+        val_json_path = DATA_DIR / self.json_filename
 
         with open(val_json_path) as f:
             val_data = json.load(f)

--- a/animal_id/embedding/config.py
+++ b/animal_id/embedding/config.py
@@ -25,6 +25,7 @@ TRAINING_CONFIG = {
 DATA_CONFIG = {
     "TRAIN_JSON_PATH": "data/identity_train.json",
     "VAL_JSON_PATH": "data/identity_val.json",
+    "TEST_JSON_PATH": "data/identity_test.json",
     "DOGFACENET_PATH": "data/dogfacenet/DogFaceNet_224resized/after_4_bis",
     "IMG_SIZE": 224,
     "BATCH_SIZE": 32,

--- a/animal_id/embedding/dataset_converter.py
+++ b/animal_id/embedding/dataset_converter.py
@@ -14,18 +14,27 @@ class EmbeddingDatasetConverter:
         source_path: str,
         output_train_json: str,
         output_val_json: str,
+        output_test_json: str,
         min_images_per_identity: int = 5,
         val_split_ratio: float = 0.15,
+        test_split_ratio: float = 0.15,
     ):
         self.source_path = source_path
         self.output_train_json = output_train_json
         self.output_val_json = output_val_json
+        self.output_test_json = output_test_json
         self.min_images_per_identity = min_images_per_identity
         self.val_split_ratio = val_split_ratio
+        self.test_split_ratio = test_split_ratio
 
     def convert(self):
         """
-        Scans DogFaceNet for identities and creates train/validation JSON files.
+        Scans DogFaceNet for identities and creates train/val/test JSON files.
+
+        The split is performed BY IDENTITY (open-set, no identity leakage): the
+        train, validation, and test sets contain disjoint identities. Validation
+        is used for model selection / early-stopping, while the held-out test set
+        is reserved for the reported retrieval metrics (MRR / top-k / TAR@FAR).
         """
         print("--- Embedding Data Preparation ---")
 
@@ -80,22 +89,29 @@ class EmbeddingDatasetConverter:
 
         train_data = []
         val_data = []
+        test_data = []
         total_images = sum(len(imgs) for imgs in data_by_identity.values())
         val_target_count = int(total_images * self.val_split_ratio)
+        test_target_count = int(total_images * self.test_split_ratio)
 
+        # Assign whole identities to test first, then val, then train so that the
+        # three identity sets are pairwise disjoint (open-set protocol).
         for identity_id in all_identity_ids:
-            # Add identities to validation set until we reach the desired ratio
-            if len(val_data) < val_target_count:
+            if len(test_data) < test_target_count:
+                test_data.extend(data_by_identity[identity_id])
+            elif len(val_data) < val_target_count:
                 val_data.extend(data_by_identity[identity_id])
             else:
                 train_data.extend(data_by_identity[identity_id])
 
         print(f"Total images: {total_images}")
         print(f"Target validation images: ~{val_target_count}")
+        print(f"Target test images: ~{test_target_count}")
 
         # Ensure output directories exist
         os.makedirs(os.path.dirname(self.output_train_json), exist_ok=True)
         os.makedirs(os.path.dirname(self.output_val_json), exist_ok=True)
+        os.makedirs(os.path.dirname(self.output_test_json), exist_ok=True)
 
         # Save to JSON
         print(f"Writing {len(train_data)} training samples to {self.output_train_json}")
@@ -106,10 +122,15 @@ class EmbeddingDatasetConverter:
         with open(self.output_val_json, "w") as f:
             json.dump(val_data, f, indent=2)
 
+        print(f"Writing {len(test_data)} test samples to {self.output_test_json}")
+        with open(self.output_test_json, "w") as f:
+            json.dump(test_data, f, indent=2)
+
         print("Dataset preparation complete!")
         print(
-            f"Training identities: {len([id for id in all_identity_ids if any(item['identity_label'] == id for item in train_data)])}"
+            f"Training identities: {len({item['identity_label'] for item in train_data})}"
         )
         print(
-            f"Validation identities: {len([id for id in all_identity_ids if any(item['identity_label'] == id for item in val_data)])}"
+            f"Validation identities: {len({item['identity_label'] for item in val_data})}"
         )
+        print(f"Test identities: {len({item['identity_label'] for item in test_data})}")

--- a/scripts/train_master.py
+++ b/scripts/train_master.py
@@ -89,9 +89,11 @@ def run_full_pipeline_benchmark(
     logger.info("STARTING FULL PIPELINE BENCHMARK")
     logger.info("=" * 60)
 
-    val_json_path = DATA_DIR / "identity_val.json"
-    if not val_json_path.exists():
-        logger.error(f"Validation JSON not found: {val_json_path}")
+    # Headline benchmark numbers are reported on the held-out TEST split (disjoint
+    # identities from train/val). Val is reserved for model selection / early-stopping.
+    test_json_path = DATA_DIR / "identity_test.json"
+    if not test_json_path.exists():
+        logger.error(f"Test JSON not found: {test_json_path}")
         return False
 
     logger.info("Initializing AnimalPipeline...")
@@ -121,8 +123,8 @@ def run_full_pipeline_benchmark(
     if has_keypoints:
         keypoint_model = ONNXKeypoint(str(ONNX_KEYPOINT_PATH))
 
-    # Load validation data
-    loader = IdentityLoader()
+    # Load held-out test data for the reported (headline) benchmark
+    loader = IdentityLoader(json_filename="identity_test.json")
     ground_truth = loader.load_validation_data(
         num_images=num_images, include_additional=include_additional
     )
@@ -134,9 +136,7 @@ def run_full_pipeline_benchmark(
     }
 
     dataset_size = "full dataset" if num_images is None else f"{num_images} images"
-    logger.info(
-        f"Found {len(ground_truth)} validation images. Processing {dataset_size}."
-    )
+    logger.info(f"Found {len(ground_truth)} test images. Processing {dataset_size}.")
 
     # Save temporary ground truth file for Evaluator
     temp_gt_path = PROJECT_ROOT / "outputs/temp_ground_truth.json"
@@ -306,6 +306,7 @@ def run_embedding_data_prep():
         source_path=DATA_CONFIG["DOGFACENET_PATH"],
         output_train_json=DATA_CONFIG["TRAIN_JSON_PATH"],
         output_val_json=DATA_CONFIG["VAL_JSON_PATH"],
+        output_test_json=DATA_CONFIG["TEST_JSON_PATH"],
     )
     dataset_converter.convert()
 

--- a/tests/unit/test_dataset_split.py
+++ b/tests/unit/test_dataset_split.py
@@ -1,0 +1,89 @@
+"""
+Tests for EmbeddingDatasetConverter's train/val/test identity split.
+
+These verify the open-set (no-leakage) protocol: the three splits must contain
+pairwise-disjoint identity sets and all three must be non-empty. The converter
+only reads filenames to build the split, so dummy (empty) image files are enough
+and the real DogFaceNet dataset is not required.
+"""
+
+import json
+
+from animal_id.embedding.dataset_converter import EmbeddingDatasetConverter
+
+
+def _make_fake_dataset(root, num_identities=20, images_per_identity=6):
+    """Create a tmp directory tree of fake identity folders with dummy images."""
+    for i in range(num_identities):
+        identity_dir = root / f"identity_{i:03d}"
+        identity_dir.mkdir(parents=True)
+        for j in range(images_per_identity):
+            (identity_dir / f"img_{j}.jpg").touch()
+
+
+def _identity_set(json_path):
+    with open(json_path) as f:
+        data = json.load(f)
+    return {item["identity_label"] for item in data}
+
+
+def test_train_val_test_splits_are_disjoint_and_non_empty(tmp_path):
+    source = tmp_path / "dogfacenet"
+    source.mkdir()
+    _make_fake_dataset(source, num_identities=20, images_per_identity=6)
+
+    train_json = tmp_path / "out" / "identity_train.json"
+    val_json = tmp_path / "out" / "identity_val.json"
+    test_json = tmp_path / "out" / "identity_test.json"
+
+    converter = EmbeddingDatasetConverter(
+        source_path=str(source),
+        output_train_json=str(train_json),
+        output_val_json=str(val_json),
+        output_test_json=str(test_json),
+        min_images_per_identity=5,
+        val_split_ratio=0.15,
+        test_split_ratio=0.15,
+    )
+    converter.convert()
+
+    train_ids = _identity_set(train_json)
+    val_ids = _identity_set(val_json)
+    test_ids = _identity_set(test_json)
+
+    # All three splits are non-empty.
+    assert train_ids, "train split is empty"
+    assert val_ids, "val split is empty"
+    assert test_ids, "test split is empty"
+
+    # Pairwise disjoint identity sets (open-set, no identity leakage).
+    assert train_ids.isdisjoint(val_ids)
+    assert train_ids.isdisjoint(test_ids)
+    assert val_ids.isdisjoint(test_ids)
+
+    # Every filtered identity ends up in exactly one split.
+    assert len(train_ids) + len(val_ids) + len(test_ids) == 20
+
+
+def test_split_is_reproducible(tmp_path):
+    """The fixed random.seed(42) must produce identical splits across runs."""
+    source = tmp_path / "dogfacenet"
+    source.mkdir()
+    _make_fake_dataset(source, num_identities=20, images_per_identity=6)
+
+    def run(out_name):
+        out = tmp_path / out_name
+        converter = EmbeddingDatasetConverter(
+            source_path=str(source),
+            output_train_json=str(out / "identity_train.json"),
+            output_val_json=str(out / "identity_val.json"),
+            output_test_json=str(out / "identity_test.json"),
+        )
+        converter.convert()
+        return (
+            _identity_set(out / "identity_train.json"),
+            _identity_set(out / "identity_val.json"),
+            _identity_set(out / "identity_test.json"),
+        )
+
+    assert run("run_a") == run("run_b")


### PR DESCRIPTION
## What

Implements audit task **#10**: introduce a held-out `identity_test.json` so the embedding pipeline stops using the validation split for **both** early-stopping and headline benchmark numbers.

- **Val** → model selection / early-stopping (unchanged)
- **Test** (new, held-out) → reported MRR / top-k / TAR@FAR

This is a prerequisite for the upcoming backbone-swap ablation (MiewID / MegaDescriptor vs ResNet50) — you can't credibly choose a backbone by selecting and reporting on the same split.

## Changes

- **`dataset_converter.py`** — `EmbeddingDatasetConverter` gains `output_test_json` + `test_split_ratio` (0.15). Carves three pairwise-disjoint identity partitions, assigning whole identities test → val → train, preserving the existing `seed(42)` by-identity (no-leakage) protocol.
- **`config.py`** — adds `TEST_JSON_PATH`.
- **`identity_loader.py`** — backward-compatible `json_filename=` param (defaults to `identity_val.json`) so the benchmark can load the test split; other callers unaffected.
- **`train_master.py`** — early-stopping stays on val; headline benchmark now evaluates on the held-out test split.
- **`tests/unit/test_dataset_split.py`** (new) — asserts the three splits are non-empty, pairwise disjoint, and reproducible across runs. Uses a synthetic identity tree (no real DogFaceNet needed).

## Notes

- No real `data/identity_*.json` files were regenerated — code-only change. The new split takes effect next time data prep runs.
- `ruff check` / `ruff format` clean; `pytest tests/` → 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)