### PR TITLE
Factor margin head/loss behind config (audit P1 #9)

### DIFF
--- a/animal_id/embedding/config.py
+++ b/animal_id/embedding/config.py
@@ -3,10 +3,29 @@ Central configuration file for the embedding model pipeline.
 """
 
 from .backbones import BackboneType
+from .losses import HeadType
 
 # --- Model Configuration ---
 # Default backbone to use for training and inference.
 DEFAULT_BACKBONE = BackboneType.RESNET50
+
+# --- Margin Head Configuration ---
+# Selects and parameterizes the train-time margin head. The default reproduces
+# the historical hardcoded behavior exactly: ArcFace with s=30, m=0.50, label
+# smoothing 0.1. Swapping HEAD_TYPE to SUBCENTER_ARCFACE (the MiewID recipe) or
+# COSFACE is a one-line change and only affects training; the embedding output
+# and ONNX inference path are unchanged.
+HEAD_CONFIG = {
+    "HEAD_TYPE": HeadType.ARCFACE,
+    # Shared margin-head hyperparameters (None => use the head's own default).
+    "ARCFACE_S": 30.0,
+    "ARCFACE_M": 0.50,
+    "LABEL_SMOOTHING": 0.1,
+    # Sub-center ArcFace: number of sub-centers per class.
+    "SUB_CENTER_K": 3,
+    # CosFace additive cosine margin (only used when HEAD_TYPE == COSFACE).
+    "COSFACE_M": 0.35,
+}
 
 # --- Training Hyperparameters ---
 TRAINING_CONFIG = {

--- a/animal_id/embedding/losses.py
+++ b/animal_id/embedding/losses.py
@@ -1,45 +1,125 @@
 """
-Defines the loss functions for metric learning.
+Defines the loss functions / margin heads for metric learning.
 
 What it's for:
-This script contains the loss functions that drive the embedding model's training.
-Instead of just classifying, these losses teach the model to create a geometrically
-meaningful embedding space, where similar items are close together and dissimilar
-items are far apart.
+This script contains the margin-based heads that drive the embedding model's
+training. Instead of just classifying, these heads teach the model to create a
+geometrically meaningful embedding space, where similar items are close together
+and dissimilar items are far apart.
 
 What it does:
-1. Implements `ArcFaceLoss`, a state-of-the-art loss function that works by enforcing
-   an additive angular margin between embeddings and their class prototypes.
-   The `ArcFaceLoss` module itself is a layer with trainable weights representing the
-   class prototypes. It outputs modified logits, which are then fed into a standard
-   CrossEntropyLoss in the main training script.
-2. Provides access to the standard PyTorch `TripletLoss` for comparison or alternative
-   training strategies.
-3. Includes a self-testing block to verify that both loss functions are implemented
+1. Defines a common `MarginHead` base class (an ``nn.Module``) that fixes the
+   shared interface every margin head exposes: an L2-normalized class-prototype
+   weight matrix and ``forward(embeddings, labels) -> logits``.
+2. Implements `ArcFaceLoss` (Additive Angular Margin), `SubCenterArcFace`
+   (K sub-centers per class, the MiewID recipe), and `CosFaceLoss` (additive
+   cosine margin), all subclassing `MarginHead`.
+3. Exposes a `HEAD_TYPES` registry plus a `build_head(...)` factory so the head
+   can be selected from configuration with a single key.
+4. Provides access to the standard PyTorch `TripletLoss` for comparison or
+   alternative training strategies.
+5. Includes a self-testing block to verify that the heads are implemented
    correctly and produce valid, non-zero loss values for non-trivial cases.
 
 How to run it:
-- This script is not typically run directly. It is imported by `training/train_embedding.py`.
-- To run the self-tests and verify the loss implementations, run from the project root:
-  `python training/losses.py`
+- This script is not typically run directly. It is imported by the embedding
+  trainer.
+- To run the self-tests, run from the project root:
+  `python -m animal_id.embedding.losses`
 
 How to interpret the results:
-When running the self-test, the script will:
-- Instantiate both ArcFaceLoss and TripletLoss.
-- Run forward passes with controlled dummy data.
-- Assert that the outputs are of the correct shape and that the loss values are
-  behaving as expected (e.g., zero for easy cases, positive for hard cases).
-- A successful run indicates the loss functions are correctly implemented.
+When running the self-test, the script will instantiate each head, run forward
+passes with controlled dummy data, and assert the outputs have the correct shape
+and produce a positive CrossEntropyLoss. A successful run indicates the heads are
+correctly implemented.
 """
 
 import math
+from enum import Enum
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 
-class ArcFaceLoss(nn.Module):
+class HeadType(str, Enum):
+    """Enumeration of the available margin head types."""
+
+    ARCFACE = "arcface"
+    SUBCENTER_ARCFACE = "subcenter_arcface"
+    COSFACE = "cosface"
+
+
+class MarginHead(nn.Module):
+    """
+    Common base class for margin-based classification heads.
+
+    A margin head owns a matrix of trainable class prototypes (one or more per
+    class) and, given a batch of L2-normalized embeddings plus integer labels,
+    returns scaled logits of shape ``(batch_size, num_classes)``. The actual
+    loss is computed with a standard ``CrossEntropyLoss`` outside this module.
+
+    Subclasses implement :meth:`forward`. The base class standardizes the
+    constructor signature, the prototype weight matrix, and the scale ``s``.
+    """
+
+    def __init__(
+        self,
+        in_features,
+        out_features,
+        s=30.0,
+        m=0.50,
+        label_smoothing=0.1,
+        num_centers=1,
+    ):
+        """
+        Args:
+            in_features (int): Size of the input embedding vectors.
+            out_features (int): Number of classes (identities).
+            s (float): Feature scaling factor.
+            m (float): Margin (interpretation depends on the subclass).
+            label_smoothing (float): Label smoothing factor. Retained on the
+                module so trainers can read it back; the actual smoothing is
+                applied by the external CrossEntropyLoss.
+            num_centers (int): Number of sub-centers (prototypes) per class.
+        """
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.s = s
+        self.m = m
+        self.label_smoothing = label_smoothing
+        self.num_centers = num_centers
+
+        # The weight matrix holds the class prototypes. With ``num_centers > 1``
+        # each class owns several sub-centers (sub-center ArcFace).
+        self.weight = nn.Parameter(
+            torch.FloatTensor(out_features * num_centers, in_features)
+        )
+        nn.init.xavier_uniform_(self.weight)
+
+    def cosine_logits(self, embeddings):
+        """
+        Cosine similarity between (already L2-normalized) embeddings and the
+        L2-normalized class prototypes, of shape ``(batch_size, out_features)``.
+
+        For multi-center heads the per-class score is the max over that class's
+        sub-centers, which is the sub-center ArcFace pooling step.
+        """
+        normalized_weights = F.normalize(self.weight, p=2, dim=1)
+        cosine = F.linear(embeddings, normalized_weights)
+
+        if self.num_centers > 1:
+            cosine = cosine.view(-1, self.out_features, self.num_centers)
+            cosine, _ = torch.max(cosine, dim=2)
+
+        return cosine
+
+    def forward(self, embeddings, labels):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class ArcFaceLoss(MarginHead):
     """
     Implementation of ArcFace loss (Additive Angular Margin Loss).
     This loss function is designed to increase the discriminative power of embeddings.
@@ -55,17 +135,14 @@ class ArcFaceLoss(nn.Module):
             m (float): Additive angular margin.
             label_smoothing (float): Label smoothing factor for cross entropy loss.
         """
-        super(ArcFaceLoss, self).__init__()
-        self.in_features = in_features
-        self.out_features = out_features
-        self.s = s
-        self.m = m
-        self.label_smoothing = label_smoothing
-
-        # The weight matrix of this layer represents the class prototypes.
-        # Each column is a prototype for a class.
-        self.weight = nn.Parameter(torch.FloatTensor(out_features, in_features))
-        nn.init.xavier_uniform_(self.weight)
+        super().__init__(
+            in_features,
+            out_features,
+            s=s,
+            m=m,
+            label_smoothing=label_smoothing,
+            num_centers=1,
+        )
 
         # Constants for numerical stability
         self.cos_m = math.cos(m)
@@ -75,19 +152,13 @@ class ArcFaceLoss(nn.Module):
         )  # Threshold to prevent theta + m from going > pi
         self.mm = math.sin(math.pi - m) * m
 
-    def forward(self, embeddings, labels):
+    def _apply_margin(self, cosine, labels):
         """
-        Args:
-            embeddings (torch.Tensor): L2-normalized input embeddings of shape (batch_size, in_features).
-            labels (torch.Tensor): Ground truth labels of shape (batch_size).
+        Apply the additive angular margin to the target-class cosine values.
+
+        Shared by ArcFace and Sub-center ArcFace (which differ only in how the
+        per-class ``cosine`` matrix is produced).
         """
-        # L2 normalize weights (class prototypes)
-        normalized_weights = F.normalize(self.weight, p=2, dim=1)
-
-        # Calculate cosine similarity between embeddings and class prototypes
-        # This is equivalent to the output of a standard fully connected layer
-        cosine = F.linear(embeddings, normalized_weights)
-
         # Convert labels to one-hot format
         one_hot = torch.zeros_like(cosine)
         one_hot.scatter_(1, labels.view(-1, 1).long(), 1)
@@ -119,6 +190,144 @@ class ArcFaceLoss(nn.Module):
         # The actual loss calculation is done with CrossEntropyLoss outside this module
         return output_logits
 
+    def forward(self, embeddings, labels):
+        """
+        Args:
+            embeddings (torch.Tensor): L2-normalized input embeddings of shape (batch_size, in_features).
+            labels (torch.Tensor): Ground truth labels of shape (batch_size).
+        """
+        cosine = self.cosine_logits(embeddings)
+        return self._apply_margin(cosine, labels)
+
+
+class SubCenterArcFace(ArcFaceLoss):
+    """
+    Sub-center ArcFace (Deng et al., ECCV'20).
+
+    Each class is represented by ``k`` sub-centers instead of a single
+    prototype. The per-class cosine score is the maximum cosine over that
+    class's ``k`` sub-centers, after which the standard ArcFace angular margin is
+    applied. The dominant sub-center soaks up the bulk of (clean) samples while
+    noisy / off-distribution samples can latch onto a minority sub-center,
+    making training robust to label noise and intra-identity appearance
+    variance. This is the loss used by MiewID.
+
+    Reference: https://ibug.doc.ic.ac.uk/media/uploads/documents/eccv_1445.pdf
+    """
+
+    def __init__(
+        self, in_features, out_features, s=30.0, m=0.50, label_smoothing=0.1, k=3
+    ):
+        """
+        Args:
+            in_features (int): Size of the input embedding vectors.
+            out_features (int): Number of classes (identities).
+            s (float): Feature scaling factor.
+            m (float): Additive angular margin.
+            label_smoothing (float): Label smoothing factor for cross entropy loss.
+            k (int): Number of sub-centers per class.
+        """
+        # Skip ArcFaceLoss.__init__ (it hardcodes num_centers=1); go straight to
+        # the grandparent MarginHead with the requested number of sub-centers,
+        # then set up the same angular-margin constants ArcFace uses.
+        MarginHead.__init__(
+            self,
+            in_features,
+            out_features,
+            s=s,
+            m=m,
+            label_smoothing=label_smoothing,
+            num_centers=k,
+        )
+        self.k = k
+
+        # Constants for numerical stability (mirrors ArcFaceLoss)
+        self.cos_m = math.cos(m)
+        self.sin_m = math.sin(m)
+        self.th = math.cos(math.pi - m)
+        self.mm = math.sin(math.pi - m) * m
+
+    # forward() is inherited from ArcFaceLoss: cosine_logits() max-pools over the
+    # k sub-centers, then _apply_margin() applies the ArcFace angular margin.
+
+
+class CosFaceLoss(MarginHead):
+    """
+    CosFace loss (Large Margin Cosine Loss).
+
+    Subtracts an additive cosine margin ``m`` from the target-class cosine
+    similarity before scaling, rather than adding an angular margin as ArcFace
+    does. Reference: https://arxiv.org/abs/1801.09414
+    """
+
+    def __init__(self, in_features, out_features, s=30.0, m=0.35, label_smoothing=0.1):
+        """
+        Args:
+            in_features (int): Size of the input embedding vectors.
+            out_features (int): Number of classes (identities).
+            s (float): Feature scaling factor.
+            m (float): Additive cosine margin.
+            label_smoothing (float): Label smoothing factor for cross entropy loss.
+        """
+        super().__init__(
+            in_features,
+            out_features,
+            s=s,
+            m=m,
+            label_smoothing=label_smoothing,
+            num_centers=1,
+        )
+
+    def forward(self, embeddings, labels):
+        """
+        Args:
+            embeddings (torch.Tensor): L2-normalized input embeddings of shape (batch_size, in_features).
+            labels (torch.Tensor): Ground truth labels of shape (batch_size).
+        """
+        cosine = self.cosine_logits(embeddings)
+
+        # Subtract the additive cosine margin from the true-class similarity.
+        one_hot = torch.zeros_like(cosine)
+        one_hot.scatter_(1, labels.view(-1, 1).long(), 1)
+        output_logits = cosine - one_hot * self.m
+
+        # Scale before passing to CrossEntropyLoss.
+        output_logits *= self.s
+        return output_logits
+
+
+# Registry mapping a HeadType to its implementing class.
+HEAD_TYPES = {
+    HeadType.ARCFACE: ArcFaceLoss,
+    HeadType.SUBCENTER_ARCFACE: SubCenterArcFace,
+    HeadType.COSFACE: CosFaceLoss,
+}
+
+
+def build_head(head_type, embedding_dim, num_classes, **kwargs):
+    """
+    Factory that instantiates the requested margin head.
+
+    Args:
+        head_type (HeadType | str): Which head to build. Accepts a ``HeadType``
+            or its string value (e.g. ``"arcface"``).
+        embedding_dim (int): Size of the input embedding vectors.
+        num_classes (int): Number of identity classes.
+        **kwargs: Forwarded to the head constructor (e.g. ``s``, ``m``,
+            ``label_smoothing``, and head-specific params like ``k``). Keys with
+            a ``None`` value are dropped so the head's own defaults apply.
+
+    Returns:
+        MarginHead: The instantiated head.
+
+    Raises:
+        ValueError: If ``head_type`` is not a recognized head.
+    """
+    head_type = HeadType(head_type)
+    head_cls = HEAD_TYPES[head_type]
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    return head_cls(embedding_dim, num_classes, **kwargs)
+
 
 # For Triplet Loss, we can use the standard PyTorch implementation.
 # The main complexity of Triplet Loss is in the data sampling (finding triplets),
@@ -128,45 +337,34 @@ TripletLoss = nn.TripletMarginLoss
 
 # --- Test script to verify loss functions --- #
 if __name__ == "__main__":
-    # --- ArcFaceLoss Test --- #
-    print("--- Testing ArcFaceLoss ---")
     num_classes = 10
     embedding_dim = 512
     batch_size = 4
 
-    # Create dummy data
     dummy_embeddings = F.normalize(torch.randn(batch_size, embedding_dim), p=2, dim=1)
     dummy_labels = torch.randint(0, num_classes, (batch_size,))
-
-    # Instantiate loss module
-    arcface = ArcFaceLoss(in_features=embedding_dim, out_features=num_classes)
-    print(f"Instantiated ArcFaceLoss for {num_classes} classes.")
-
-    # Perform forward pass
-    output_logits = arcface(dummy_embeddings, dummy_labels)
-
-    # Verify output shape
-    print(f"Output logits shape: {output_logits.shape}")
-    assert output_logits.shape == (batch_size, num_classes)
-
-    # Verify that the logits for the target classes have been modified
     criterion = nn.CrossEntropyLoss()
-    loss = criterion(output_logits, dummy_labels)
-    print(f"Calculated CrossEntropyLoss: {loss.item()}")
-    assert loss.item() > 0
 
-    print("ArcFaceLoss test passed!")
+    # --- Margin heads --- #
+    for head_type in HeadType:
+        print(f"--- Testing {head_type.value} ---")
+        head = build_head(head_type, embedding_dim, num_classes)
+        output_logits = head(dummy_embeddings, dummy_labels)
+        print(f"Output logits shape: {output_logits.shape}")
+        assert output_logits.shape == (batch_size, num_classes)
+
+        loss = criterion(output_logits, dummy_labels)
+        print(f"Calculated CrossEntropyLoss: {loss.item()}")
+        assert loss.item() > 0
+        loss.backward()
+        print(f"{head_type.value} test passed!\n")
 
     # --- TripletLoss Test --- #
-    print("\n--- Testing TripletLoss ---")
+    print("--- Testing TripletLoss ---")
     margin = 1.0
     triplet_loss = TripletLoss(margin=margin, p=2)  # Explicitly use L2 distance
 
     # Test Case 1: Easy case (loss should be 0)
-    # Negative is already further from anchor than positive is.
-    # dist(a,p) = sqrt((0.1-0)^2 + (0.9-1)^2) = sqrt(0.02) = 0.1414
-    # dist(a,n) = sqrt((1-0)^2 + (0-1)^2) = sqrt(2) = 1.414
-    # loss = max(0.1414 - 1.414 + 1.0, 0) = max(-0.27, 0) = 0
     anchor_easy = torch.tensor([[0.0, 1.0]])
     positive_easy = torch.tensor([[0.1, 0.9]])
     negative_easy = torch.tensor([[1.0, 0.0]])
@@ -175,10 +373,6 @@ if __name__ == "__main__":
     assert loss_easy.item() == 0, "Easy case should result in zero loss"
 
     # Test Case 2: Hard case (loss should be > 0)
-    # Negative is closer to anchor than positive is.
-    # dist(a,p) = 0.5
-    # dist(a,n) = 0.2
-    # loss = max(0.5 - 0.2 + 1.0, 0) = max(1.3, 0) = 1.3
     anchor_hard = torch.tensor([[0.0, 0.0]])
     positive_hard = torch.tensor([[0.5, 0.0]])
     negative_hard = torch.tensor([[0.2, 0.0]])

--- a/animal_id/embedding/models.py
+++ b/animal_id/embedding/models.py
@@ -27,7 +27,31 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from animal_id.embedding.backbones import BackboneType, get_backbone
-from animal_id.embedding.losses import ArcFaceLoss
+from animal_id.embedding.config import HEAD_CONFIG
+from animal_id.embedding.losses import HeadType, build_head
+
+
+def _head_kwargs_from_config(head_type, config):
+    """
+    Map the project ``HEAD_CONFIG`` dict to keyword arguments for a margin head.
+
+    Only the keys relevant to the selected ``head_type`` are forwarded. The
+    shared scale/margin/label-smoothing keys map to ``s`` / ``m`` /
+    ``label_smoothing``; per-head extras (sub-center ``k``, CosFace ``m``) are
+    added on top. ``build_head`` drops any ``None`` values so each head falls
+    back to its own defaults when a key is unset.
+    """
+    kwargs = {
+        "s": config.get("ARCFACE_S"),
+        "m": config.get("ARCFACE_M"),
+        "label_smoothing": config.get("LABEL_SMOOTHING"),
+    }
+    if head_type == HeadType.SUBCENTER_ARCFACE:
+        kwargs["k"] = config.get("SUB_CENTER_K")
+    elif head_type == HeadType.COSFACE:
+        # CosFace uses its own additive cosine margin rather than ARCFACE_M.
+        kwargs["m"] = config.get("COSFACE_M")
+    return kwargs
 
 
 class EmbeddingNet(nn.Module):
@@ -94,6 +118,8 @@ class AnimalEmbeddingModel(nn.Module):
         num_classes: Optional[int] = None,
         embedding_dim: int = 512,
         pretrained: bool = True,
+        head_type: Optional[HeadType] = None,
+        head_config: Optional[dict] = None,
     ):
         """
         Args:
@@ -102,6 +128,11 @@ class AnimalEmbeddingModel(nn.Module):
                                          If None, model is in inference mode (no classification head).
             embedding_dim (int): Size of embedding vector.
             pretrained (bool): Use ImageNet weights.
+            head_type (Optional[HeadType]): Margin head to use. Defaults to
+                ``head_config["HEAD_TYPE"]`` (ArcFace via the project config),
+                preserving historical behavior.
+            head_config (Optional[dict]): Head-hyperparameter dict. Defaults to
+                ``animal_id.embedding.config.HEAD_CONFIG``.
         """
         super(AnimalEmbeddingModel, self).__init__()
 
@@ -110,7 +141,15 @@ class AnimalEmbeddingModel(nn.Module):
         )
 
         if num_classes is not None:
-            self.head = ArcFaceLoss(embedding_dim, num_classes)
+            head_config = head_config if head_config is not None else HEAD_CONFIG
+            head_type = head_type if head_type is not None else head_config["HEAD_TYPE"]
+            head_type = HeadType(head_type)
+            self.head = build_head(
+                head_type,
+                embedding_dim,
+                num_classes,
+                **_head_kwargs_from_config(head_type, head_config),
+            )
         else:
             self.head = None
 

--- a/tests/unit/test_losses.py
+++ b/tests/unit/test_losses.py
@@ -1,0 +1,145 @@
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from animal_id.embedding.losses import (
+    HEAD_TYPES,
+    ArcFaceLoss,
+    CosFaceLoss,
+    HeadType,
+    MarginHead,
+    SubCenterArcFace,
+    build_head,
+)
+
+EMBEDDING_DIM = 32
+NUM_CLASSES = 6
+BATCH_SIZE = 4
+
+
+def _dummy_inputs():
+    embeddings = F.normalize(torch.randn(BATCH_SIZE, EMBEDDING_DIM), p=2, dim=1)
+    labels = torch.randint(0, NUM_CLASSES, (BATCH_SIZE,))
+    return embeddings, labels
+
+
+@pytest.mark.parametrize("head_type", list(HeadType))
+def test_head_forward_shape_and_backward(head_type):
+    """Each head maps (batch, dim) embeddings + int labels to (batch, classes) logits
+    and supports a backward pass."""
+    embeddings, labels = _dummy_inputs()
+    embeddings.requires_grad_(True)
+
+    head = build_head(head_type, EMBEDDING_DIM, NUM_CLASSES)
+    assert isinstance(head, MarginHead)
+
+    logits = head(embeddings, labels)
+    assert logits.shape == (BATCH_SIZE, NUM_CLASSES)
+
+    loss = nn.CrossEntropyLoss()(logits, labels)
+    assert loss.item() > 0
+
+    loss.backward()
+    # Gradients should flow to both the head weights and the embeddings.
+    assert head.weight.grad is not None
+    assert embeddings.grad is not None
+
+
+@pytest.mark.parametrize(
+    "head_type,expected_cls",
+    [
+        (HeadType.ARCFACE, ArcFaceLoss),
+        (HeadType.SUBCENTER_ARCFACE, SubCenterArcFace),
+        (HeadType.COSFACE, CosFaceLoss),
+    ],
+)
+def test_build_head_dispatch(head_type, expected_cls):
+    """The factory dispatches each HEAD_TYPE to the right class."""
+    head = build_head(head_type, EMBEDDING_DIM, NUM_CLASSES)
+    assert type(head) is expected_cls
+    assert HEAD_TYPES[head_type] is expected_cls
+
+
+def test_build_head_accepts_string_value():
+    """The factory accepts the enum's string value as well as the enum."""
+    head = build_head("arcface", EMBEDDING_DIM, NUM_CLASSES)
+    assert isinstance(head, ArcFaceLoss)
+
+
+def test_build_head_rejects_unknown_type():
+    with pytest.raises(ValueError):
+        build_head("not_a_real_head", EMBEDDING_DIM, NUM_CLASSES)
+
+
+def test_build_head_drops_none_kwargs():
+    """None-valued kwargs fall back to the head's own defaults."""
+    head = build_head("cosface", EMBEDDING_DIM, NUM_CLASSES, m=None)
+    # CosFace default margin is 0.35.
+    assert head.m == pytest.approx(0.35)
+
+
+def test_subcenter_weight_shape_and_k():
+    """Sub-center ArcFace allocates k prototypes per class."""
+    k = 3
+    head = build_head(HeadType.SUBCENTER_ARCFACE, EMBEDDING_DIM, NUM_CLASSES, k=k)
+    assert head.k == k
+    assert head.num_centers == k
+    assert head.weight.shape == (NUM_CLASSES * k, EMBEDDING_DIM)
+
+
+def test_arcface_default_numerically_unchanged():
+    """The factory-built ArcFace with default config must reproduce the output of
+    a direct ArcFaceLoss instantiation (behavior-preserving refactor)."""
+    torch.manual_seed(0)
+    direct = ArcFaceLoss(EMBEDDING_DIM, NUM_CLASSES)
+
+    torch.manual_seed(0)
+    via_factory = build_head(HeadType.ARCFACE, EMBEDDING_DIM, NUM_CLASSES)
+
+    # Same default hyperparameters.
+    assert direct.s == via_factory.s == 30.0
+    assert direct.m == via_factory.m == 0.50
+    assert direct.label_smoothing == via_factory.label_smoothing == 0.1
+
+    # Identical xavier-init weights given the same seed.
+    assert torch.allclose(direct.weight, via_factory.weight)
+
+    embeddings, labels = _dummy_inputs()
+    assert torch.allclose(direct(embeddings, labels), via_factory(embeddings, labels))
+
+
+def test_subcenter_reduces_to_arcface_when_k_is_one():
+    """With k=1 sub-center ArcFace and ArcFace produce identical logits given the
+    same prototype weights."""
+    sub = SubCenterArcFace(EMBEDDING_DIM, NUM_CLASSES, k=1)
+    arc = ArcFaceLoss(EMBEDDING_DIM, NUM_CLASSES)
+    with torch.no_grad():
+        arc.weight.copy_(sub.weight)
+
+    embeddings, labels = _dummy_inputs()
+    assert torch.allclose(sub(embeddings, labels), arc(embeddings, labels))
+
+
+def test_cosface_subtracts_cosine_margin():
+    """CosFace logits equal s*(cosine - m) at target positions and s*cosine
+    elsewhere."""
+    head = CosFaceLoss(EMBEDDING_DIM, NUM_CLASSES, s=30.0, m=0.35)
+    embeddings, labels = _dummy_inputs()
+
+    cosine = head.cosine_logits(embeddings)
+    logits = head(embeddings, labels)
+
+    one_hot = torch.zeros_like(cosine)
+    one_hot.scatter_(1, labels.view(-1, 1), 1)
+    expected = (cosine - one_hot * head.m) * head.s
+    assert torch.allclose(logits, expected)
+
+
+def test_arcface_th_mm_constants():
+    """Sanity-check the angular-margin numerical-stability constants are set."""
+    head = ArcFaceLoss(EMBEDDING_DIM, NUM_CLASSES, m=0.5)
+    assert head.cos_m == pytest.approx(math.cos(0.5))
+    assert head.sin_m == pytest.approx(math.sin(0.5))


### PR DESCRIPTION
## What

Implements audit task **#9**: make swapping the train-time margin head — ArcFace ↔ Sub-center ArcFace ↔ CosFace — a one-line config change instead of a 4-file edit. This unblocks the upcoming backbone-swap ablation, whose MiewID-style recipe uses **Sub-center ArcFace**.

Train-time only: the 512-d L2-normalized embedding output and the ONNX inference/export path are unchanged.

## Changes

- **`losses.py`** — new `MarginHead` base class (shared `cosine_logits` / `forward` contract). `ArcFaceLoss` now subclasses it with **identical math**. Adds:
  - **`SubCenterArcFace`** — K sub-centers per class (default K=3), max-pool over sub-centers then ArcFace margin; reduces exactly to ArcFace at K=1.
  - **`CosFaceLoss`** — additive cosine margin.
  - `HeadType` enum + `HEAD_TYPES` registry + `build_head(head_type, embedding_dim, num_classes, **kwargs)` factory.
- **`config.py`** — new `HEAD_CONFIG` section (separate from `DATA_CONFIG`). **Defaults reproduce today's ArcFace behavior exactly** (s=30, m=0.50, label smoothing 0.1); `SUB_CENTER_K=3`, `COSFACE_M=0.35` apply only when selected.
- **`models.py`** — `AnimalEmbeddingModel` dispatches via `build_head()` from config instead of hardcoding `ArcFaceLoss`. `self.head` still holds the head, so the trainer's differential-LR optimizer is untouched.
- **`tests/unit/test_losses.py`** (new) — per-head forward shape + backward, factory dispatch per `HeadType`, string-value acceptance, unknown-type error, sub-center==ArcFace at K=1, CosFace margin formula, and a **numerical-equivalence test** asserting the factory-built default ArcFace matches the old direct instantiation bit-for-bit.

## Notes

- Behavior-preserving by default — existing ArcFace training and trained models are unaffected.
- `ruff check` / `ruff format` clean; `pytest tests/` → 59 passed. ONNX parity test still passes (head is train-time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)