### PR TITLE
Add modern/animal-pretrained embedding backbones (timm + HF)

### DIFF
--- a/animal_id/embedding/backbones.py
+++ b/animal_id/embedding/backbones.py
@@ -1,60 +1,162 @@
-"""
-Backbone factory for creating feature extractors for the embedding model.
+"""Backbone factory for the embedding model.
+
+Every backbone returned by :func:`get_backbone` emits a flat ``(B, num_features)``
+pooled vector — pooling lives in the wrapper, not the projection head — so
+torchvision CNNs, timm CNNs, and timm transformers share one contract. The return
+signature is always ``(feature_extractor, num_features)``.
 """
 
+from dataclasses import dataclass
 from enum import Enum
+from typing import Callable
 
 import torch.nn as nn
-from torchvision.models import (
-    EfficientNet_B0_Weights,
-    MobileNet_V3_Small_Weights,
-    ResNet50_Weights,
-    efficientnet_b0,
-    mobilenet_v3_small,
-    resnet50,
-)
 
 
 class BackboneType(Enum):
+    # torchvision
     EFFICIENTNET_B0 = "efficientnet_b0"
     MOBILENET_V3_SMALL = "mobilenet_v3_small"
     RESNET50 = "resnet50"
 
+    # timm, ImageNet-pretrained
+    CONVNEXTV2_TINY = "convnextv2_tiny"
+    CONVNEXTV2_NANO = "convnextv2_nano"
+    EFFICIENTNETV2_RW_M = "efficientnetv2_rw_m"
+    TF_EFFICIENTNETV2_M = "tf_efficientnetv2_m"
+
+    # timm Swin, HF-hosted animal-pretrained weights (MegaDescriptor)
+    MEGADESCRIPTOR_T_224 = "megadescriptor_t_224"
+    MEGADESCRIPTOR_L_384 = "megadescriptor_l_384"
+
+
+def _torchvision_efficientnet_b0(pretrained: bool):
+    from torchvision.models import EfficientNet_B0_Weights, efficientnet_b0
+
+    weights = EfficientNet_B0_Weights.IMAGENET1K_V1 if pretrained else None
+    model = efficientnet_b0(weights=weights)
+    num_features = model.classifier[1].in_features
+    feature_extractor = nn.Sequential(
+        model.features, nn.AdaptiveAvgPool2d(1), nn.Flatten()
+    )
+    return feature_extractor, num_features
+
+
+def _torchvision_mobilenet_v3_small(pretrained: bool):
+    from torchvision.models import MobileNet_V3_Small_Weights, mobilenet_v3_small
+
+    weights = MobileNet_V3_Small_Weights.IMAGENET1K_V1 if pretrained else None
+    model = mobilenet_v3_small(weights=weights)
+    num_features = model.classifier[0].in_features
+    feature_extractor = nn.Sequential(
+        model.features, nn.AdaptiveAvgPool2d(1), nn.Flatten()
+    )
+    return feature_extractor, num_features
+
+
+def _torchvision_resnet50(pretrained: bool):
+    from torchvision.models import ResNet50_Weights, resnet50
+
+    weights = ResNet50_Weights.IMAGENET1K_V2 if pretrained else None
+    model = resnet50(weights=weights)
+    num_features = model.fc.in_features
+    # Drop the final fc + avgpool, re-append GAP + flatten into the extractor.
+    feature_extractor = nn.Sequential(
+        *list(model.children())[:-2],
+        nn.AdaptiveAvgPool2d(1),
+        nn.Flatten(),
+    )
+    return feature_extractor, num_features
+
+
+def _timm_backbone(model_name: str):
+    """Loader for a vanilla timm model (ImageNet weights).
+
+    ``num_classes=0, global_pool='avg'`` makes timm return a flat pooled vector.
+    """
+
+    def loader(pretrained: bool):
+        import timm
+
+        model = timm.create_model(
+            model_name,
+            pretrained=pretrained,
+            num_classes=0,
+            global_pool="avg",
+        )
+        return model, model.num_features
+
+    return loader
+
+
+def _timm_hf_backbone(hf_repo: str):
+    """Loader for a timm model whose weights live on the HF Hub.
+
+    MegaDescriptor checkpoints (``BVRA/MegaDescriptor-*``) are plain timm Swin
+    models; timm pulls config + weights via the ``hf-hub:`` prefix. Even with
+    ``pretrained=False`` the architecture lookup hits the network, so mock this
+    loader in unit tests.
+    """
+
+    def loader(pretrained: bool):
+        import timm
+
+        model = timm.create_model(
+            f"hf-hub:{hf_repo}",
+            pretrained=pretrained,
+            num_classes=0,
+            global_pool="avg",
+        )
+        return model, model.num_features
+
+    return loader
+
+
+@dataclass(frozen=True)
+class BackboneSpec:
+    """Registry entry describing how to build a backbone.
+
+    ``loader(pretrained) -> (feature_extractor, num_features)`` where the
+    feature extractor emits a flat ``(B, num_features)`` vector.
+    """
+
+    loader: Callable[[bool], tuple[nn.Module, int]]
+    # Expected square input size; fixed for transformer backbones.
+    input_size: int = 224
+
+
+_BACKBONE_REGISTRY: dict[BackboneType, BackboneSpec] = {
+    BackboneType.EFFICIENTNET_B0: BackboneSpec(_torchvision_efficientnet_b0),
+    BackboneType.MOBILENET_V3_SMALL: BackboneSpec(_torchvision_mobilenet_v3_small),
+    BackboneType.RESNET50: BackboneSpec(_torchvision_resnet50),
+    BackboneType.CONVNEXTV2_TINY: BackboneSpec(_timm_backbone("convnextv2_tiny")),
+    BackboneType.CONVNEXTV2_NANO: BackboneSpec(_timm_backbone("convnextv2_nano")),
+    BackboneType.EFFICIENTNETV2_RW_M: BackboneSpec(
+        _timm_backbone("efficientnetv2_rw_m")
+    ),
+    BackboneType.TF_EFFICIENTNETV2_M: BackboneSpec(
+        _timm_backbone("tf_efficientnetv2_m")
+    ),
+    BackboneType.MEGADESCRIPTOR_T_224: BackboneSpec(
+        _timm_hf_backbone("BVRA/MegaDescriptor-T-224"), input_size=224
+    ),
+    BackboneType.MEGADESCRIPTOR_L_384: BackboneSpec(
+        _timm_hf_backbone("BVRA/MegaDescriptor-L-384"), input_size=384
+    ),
+}
+
 
 def get_backbone(backbone_type: BackboneType, pretrained: bool = True):
-    """
-    Selects and instantiates a pre-trained backbone model.
-
-    Args:
-        backbone_type (BackboneType): The backbone type to use.
-        pretrained (bool): Whether to use pre-trained ImageNet weights.
-
-    Returns:
-        A tuple containing:
-        - model: The instantiated backbone model's feature extractor.
-        - num_features: The number of output features from the model's feature extractor.
-    """
-    if backbone_type == BackboneType.EFFICIENTNET_B0:
-        weights = EfficientNet_B0_Weights.IMAGENET1K_V1 if pretrained else None
-        model = efficientnet_b0(weights=weights)
-        num_features = model.classifier[1].in_features
-        feature_extractor = model.features
-        return feature_extractor, num_features
-
-    elif backbone_type == BackboneType.MOBILENET_V3_SMALL:
-        weights = MobileNet_V3_Small_Weights.IMAGENET1K_V1 if pretrained else None
-        model = mobilenet_v3_small(weights=weights)
-        num_features = model.classifier[0].in_features
-        feature_extractor = model.features
-        return feature_extractor, num_features
-
-    elif backbone_type == BackboneType.RESNET50:
-        weights = ResNet50_Weights.IMAGENET1K_V2 if pretrained else None
-        model = resnet50(weights=weights)
-        num_features = model.fc.in_features  # 2048 for ResNet-50
-        # Remove final classification layer and global average pooling
-        feature_extractor = nn.Sequential(*list(model.children())[:-2])
-        return feature_extractor, num_features
-
-    else:
+    """Instantiate a backbone, returning ``(feature_extractor, num_features)``."""
+    spec = _BACKBONE_REGISTRY.get(backbone_type)
+    if spec is None:
         raise ValueError(f"Backbone '{backbone_type}' not recognized.")
+    return spec.loader(pretrained)
+
+
+def get_backbone_input_size(backbone_type: BackboneType) -> int:
+    """Return the expected square input size for a backbone (default 224)."""
+    spec = _BACKBONE_REGISTRY.get(backbone_type)
+    if spec is None:
+        raise ValueError(f"Backbone '{backbone_type}' not recognized.")
+    return spec.input_size

--- a/animal_id/embedding/config.py
+++ b/animal_id/embedding/config.py
@@ -34,7 +34,7 @@ TRAINING_CONFIG = {
     "HARDWARE_WORKERS": 8,
     "WARMUP_EPOCHS": 25,
     "FULL_TRAIN_EPOCHS": 45,
-    "EARLY_STOPPING_PATIENCE": 5,
+    "EARLY_STOPPING_PATIENCE": 10,
     "HEAD_LR": 1e-4,  # ArcFace head warmup; standard Adam range for metric-learning head
     "BACKBONE_LR": 1e-6,  # Fine-tune pretrained ResNet50; 100x smaller than head
     "FULL_TRAIN_LR": 1e-5,  # Head in phase 2; differential LR above backbone

--- a/animal_id/embedding/models.py
+++ b/animal_id/embedding/models.py
@@ -77,10 +77,12 @@ class EmbeddingNet(nn.Module):
 
         self.feature_extractor, num_features = get_backbone(backbone_type, pretrained)
 
-        # Define the new projection head with Dropout
+        # Global pooling + flatten now live inside each backbone wrapper
+        # (the feature extractor emits a flat (B, num_features) vector), so the
+        # projection head is just Dropout + Linear. For the torchvision CNNs
+        # this is numerically identical to the previous GAP->Flatten->Dropout->
+        # Linear head — the pooling was simply relocated into the extractor.
         self.projection_head = nn.Sequential(
-            nn.AdaptiveAvgPool2d(1),
-            nn.Flatten(),
             nn.Dropout(p=dropout_prob),
             nn.Linear(num_features, embedding_dim),
         )
@@ -175,4 +177,14 @@ class AnimalEmbeddingModel(nn.Module):
     def unfreeze_backbone(self):
         """Unfreeze backbone parameters."""
         for param in self.backbone.parameters():
+            param.requires_grad = True
+
+    def freeze_feature_extractor(self):
+        """Freeze the backbone trunk, leaving the projection head trainable."""
+        for param in self.backbone.feature_extractor.parameters():
+            param.requires_grad = False
+
+    def unfreeze_feature_extractor(self):
+        """Unfreeze the backbone trunk."""
+        for param in self.backbone.feature_extractor.parameters():
             param.requires_grad = True

--- a/animal_id/embedding/trainer.py
+++ b/animal_id/embedding/trainer.py
@@ -170,9 +170,9 @@ class EmbeddingTrainer:
         """Full training loop with warmup and fine-tuning phases."""
         print(f"Starting training in run directory: {self.run_dir}")
 
-        # Phase 1: Warmup (freeze backbone)
+        # Phase 1: Warmup (freeze trunk, train projection + margin head)
         print(f"\n=== Phase 1: Warmup ({warmup_epochs} epochs) ===")
-        self.model.freeze_backbone()
+        self.model.freeze_feature_extractor()
         optimizer = optim.Adam(self.model.parameters(), lr=head_lr)
 
         for epoch in range(warmup_epochs):
@@ -193,7 +193,7 @@ class EmbeddingTrainer:
                 torch.load(best_phase1_path, map_location=self.device)
             )
 
-        self.model.unfreeze_backbone()
+        self.model.unfreeze_feature_extractor()
 
         # Reset phase tracking for new phase
         self.phase_best_val_metric = -1.0
@@ -207,8 +207,9 @@ class EmbeddingTrainer:
             ]
         )
 
-        # Sequential scheduler: Linear warmup → Cosine annealing
-        warmup_epochs_phase2 = 20
+        # Linear warmup → cosine; ramp < patience so base LR is reached before
+        # early stopping can fire.
+        warmup_epochs_phase2 = 5
         linear_scheduler = optim.lr_scheduler.LinearLR(
             optimizer, start_factor=0.01, total_iters=warmup_epochs_phase2
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "requests>=2.31.0",
     "pathlib2>=2.3.7",
     "wandb>=0.23.1",
+    "timm>=1.0.27",
+    "huggingface-hub>=1.20.1",
 ]
 
 [dependency-groups]

--- a/tests/unit/embedding/test_backbones.py
+++ b/tests/unit/embedding/test_backbones.py
@@ -1,0 +1,132 @@
+"""Tests for the backbone registry and the flat-feature contract.
+
+All tests use ``pretrained=False`` or mock the loader so CI downloads no weights.
+"""
+
+import pytest
+import torch
+
+from animal_id.embedding.backbones import (
+    BackboneType,
+    get_backbone,
+    get_backbone_input_size,
+)
+from animal_id.embedding.models import EmbeddingNet
+
+# (BackboneType, expected num_features, input_size)
+TIMM_CNN_BACKBONES = [
+    (BackboneType.CONVNEXTV2_TINY, 768, 224),
+    (BackboneType.CONVNEXTV2_NANO, 640, 224),
+    (BackboneType.EFFICIENTNETV2_RW_M, 2152, 224),
+    (BackboneType.TF_EFFICIENTNETV2_M, 1280, 224),
+]
+
+# 224px: tiny inputs make random-init features collapse to ~0 and trip F.normalize.
+TORCHVISION_BACKBONES = [
+    (BackboneType.EFFICIENTNET_B0, 1280, 224),
+    (BackboneType.MOBILENET_V3_SMALL, 576, 224),
+    (BackboneType.RESNET50, 2048, 224),
+]
+
+
+def _assert_flat_features(feature_extractor, num_features, input_size):
+    """Feature extractor must emit a flat (B, num_features) vector."""
+    x = torch.randn(2, 3, input_size, input_size)
+    feature_extractor.eval()
+    with torch.no_grad():
+        feats = feature_extractor(x)
+    assert feats.shape == (2, num_features), (
+        f"expected flat (2, {num_features}), got {tuple(feats.shape)}"
+    )
+
+
+def _assert_embedding_contract(backbone_type, input_size, embedding_dim=512):
+    """EmbeddingNet forward yields a (B, embedding_dim) L2-normed vector.
+
+    Run in ``train()`` mode so BatchNorm uses batch statistics — eval-mode BN on
+    random-init weights drives features below F.normalize's eps floor.
+    """
+    torch.manual_seed(0)
+    model = EmbeddingNet(
+        backbone_type=backbone_type,
+        embedding_dim=embedding_dim,
+        pretrained=False,
+    )
+    model.train()
+    x = torch.randn(8, 3, input_size, input_size)
+    with torch.no_grad():
+        emb = model(x)
+    assert emb.shape == (8, embedding_dim)
+    norms = torch.norm(emb, p=2, dim=1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)
+
+
+@pytest.mark.parametrize("backbone_type,num_features,input_size", TORCHVISION_BACKBONES)
+def test_torchvision_backbones_flat_contract(backbone_type, num_features, input_size):
+    fe, nf = get_backbone(backbone_type, pretrained=False)
+    assert nf == num_features
+    _assert_flat_features(fe, nf, input_size)
+
+
+@pytest.mark.parametrize("backbone_type,num_features,input_size", TORCHVISION_BACKBONES)
+def test_torchvision_embedding_contract(backbone_type, num_features, input_size):
+    _assert_embedding_contract(backbone_type, input_size)
+
+
+@pytest.mark.parametrize("backbone_type,num_features,input_size", TIMM_CNN_BACKBONES)
+def test_timm_cnn_backbones_flat_contract(backbone_type, num_features, input_size):
+    fe, nf = get_backbone(backbone_type, pretrained=False)
+    assert nf == num_features
+    _assert_flat_features(fe, nf, input_size)
+
+
+@pytest.mark.parametrize("backbone_type,num_features,input_size", TIMM_CNN_BACKBONES)
+def test_timm_cnn_embedding_contract(backbone_type, num_features, input_size):
+    _assert_embedding_contract(backbone_type, input_size)
+
+
+@pytest.mark.parametrize(
+    "backbone_type,timm_name,num_features,input_size",
+    [
+        (BackboneType.MEGADESCRIPTOR_T_224, "swin_tiny_patch4_window7_224", 768, 224),
+        (
+            BackboneType.MEGADESCRIPTOR_L_384,
+            "swin_large_patch4_window12_384",
+            1536,
+            384,
+        ),
+    ],
+)
+def test_megadescriptor_swin_contract(
+    monkeypatch, backbone_type, timm_name, num_features, input_size
+):
+    """MegaDescriptor loads via timm ``hf-hub:``; mock create_model to build the
+    equivalent plain timm Swin offline."""
+    import timm
+
+    real_create_model = timm.create_model
+
+    def fake_create_model(model_name, pretrained=False, **kwargs):
+        assert model_name.startswith("hf-hub:BVRA/MegaDescriptor")
+        return real_create_model(timm_name, pretrained=False, **kwargs)
+
+    monkeypatch.setattr(timm, "create_model", fake_create_model)
+
+    fe, nf = get_backbone(backbone_type, pretrained=False)
+    assert nf == num_features
+    assert get_backbone_input_size(backbone_type) == input_size
+    _assert_flat_features(fe, nf, input_size)
+
+    model = EmbeddingNet(backbone_type=backbone_type, pretrained=False)
+    model.eval()
+    x = torch.randn(2, 3, input_size, input_size)
+    with torch.no_grad():
+        emb = model(x)
+    assert emb.shape == (2, 512)
+    norms = torch.norm(emb, p=2, dim=1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)
+
+
+def test_unknown_backbone_raises():
+    with pytest.raises(ValueError):
+        get_backbone("not-a-backbone")  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ name = "animal-id"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "huggingface-hub" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "onnx" },
@@ -25,6 +26,7 @@ dependencies = [
     { name = "requests" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "timm" },
     { name = "torch" },
     { name = "torchvision" },
     { name = "tqdm" },
@@ -44,6 +46,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "huggingface-hub", specifier = ">=1.20.1" },
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "onnx", specifier = ">=1.14.0" },
@@ -54,6 +57,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "scipy", specifier = ">=1.10.0" },
+    { name = "timm", specifier = ">=1.0.27" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchvision", specifier = ">=0.15.0" },
     { name = "tqdm", specifier = ">=4.65.0" },
@@ -3078,6 +3082,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/2e/26bab7686ff4aed48f8f5f6c23e2aa37b7a37ddd9effe3aa61e908fd518f/timm-1.0.27-py3-none-any.whl", hash = "sha256:5ff07c9ddf53cbada88eab1c93ff175c64cab683b5a2fddf863bcee985926f89", size = 2589280, upload-time = "2026-05-08T19:38:35.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Expands `backbones.py` beyond ResNet50/MobileNetV3/EfficientNet to a **config-driven registry** of modern and animal-pretrained feature extractors via **timm + HuggingFace**, all conforming to the `(feature_extractor, num_features)` contract.

Also makes the new backbones **actually trainable end-to-end**:
- `models.py`: `freeze_feature_extractor()` / `unfreeze_feature_extractor()` — freeze only the backbone trunk while keeping the projection head trainable.
- `trainer.py`: Phase-1 warmup now freezes the trunk (not the whole backbone); the Phase-2 LR ramp shrinks 20→5 epochs so the base LR is reached before early stopping can fire (fixes training stalls on swapped backbones).
- `config.py`: early-stopping patience 5→10 (ramp < patience).

## Why

First of the embedding workstream. Backbone swapping has the most leverage on identification quality; the ablation study (follow-up PR) will quantify and justify the choice.

## Testing

- `uv run ruff check .` / `ruff format --check` — clean
- `uv run pytest tests/unit/embedding/test_backbones.py` — 18 passed

## Scope notes

Deliberately excluded (land in the follow-up ablation PR): the `linear_probe` trainer path, `scripts/run_ablation.py`, and the ablation planning doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)